### PR TITLE
Handle maintenance page fetch errors

### DIFF
--- a/front/src/lib/api/strapi.ts
+++ b/front/src/lib/api/strapi.ts
@@ -44,13 +44,17 @@ export async function fetchAPI<T>(
 /**
  * Récupère les données de la page de maintenance
  */
-export async function getMaintenancePage(): Promise<StrapiResponse<MaintenanceContent>> {
+export async function getMaintenancePage(): Promise<StrapiResponse<MaintenanceContent> | null> {
     try {
         return await fetchAPI<StrapiResponse<MaintenanceContent>>(
             'maintenance?populate=*'
         );
     } catch (error) {
         console.error(`Erreur lors de la récupération de la page de maintenance: ${error}`);
+        if (error instanceof Error && error.message.includes('404')) {
+            return null;
+        }
+        throw error;
     }
 }
 

--- a/front/src/pages/index.astro
+++ b/front/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
 import { getMaintenancePage } from '../lib/api/strapi';
-import type { MaintenanceContent } from '../interfaces/strapi';
+import type { StrapiResponse, MaintenanceContent } from '../interfaces/strapi';
 import MarkdownContent from '../components/MarkdownContent.astro';
 import BaseLayout from '../layouts/Layout.astro';
 
@@ -8,6 +8,16 @@ import BaseLayout from '../layouts/Layout.astro';
 let title = "";
 let message = "";
 
+let maintenance: StrapiResponse<MaintenanceContent> | null = null;
+try {
+    maintenance = await getMaintenancePage();
+    if (maintenance) {
+        title = maintenance.data.attributes.title;
+        message = maintenance.data.attributes.message;
+    }
+} catch (error) {
+    console.error('Erreur lors de la récupération de la page de maintenance:', error);
+}
 
 export async function get() {
     return {


### PR DESCRIPTION
## Summary
- return `null` on 404 when retrieving maintenance content
- handle thrown errors when fetching maintenance page from index

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot use server-rendered pages without an adapter)*

------
https://chatgpt.com/codex/tasks/task_e_68be04fef4448327bd1b5e076e181cbf