### PR TITLE
Fix global styles loading

### DIFF
--- a/front/src/layouts/Layout.astro
+++ b/front/src/layouts/Layout.astro
@@ -1,4 +1,5 @@
 ---
+import '../styles/main.scss';
 //import { ViewTransitions } from 'astro:transitions';
 
 interface Props {
@@ -66,11 +67,8 @@ const ogImageUrl = image.startsWith('http') ? image : `${siteUrl}${image}`;
 	<!-- Transitions de page -->
 	<!--<ViewTransitions />-->
 
-	<!-- Styles globaux -->
-	<link rel="stylesheet" href="/styles/global.css" />
-
-	<!-- Slot pour des styles ou scripts supplémentaires -->
-	<slot name="head" />
+        <!-- Slot pour des styles ou scripts supplémentaires -->
+        <slot name="head" />
 </head>
 
 <body class={bodyClass}>

--- a/front/src/styles/main.scss
+++ b/front/src/styles/main.scss
@@ -1,10 +1,6 @@
 // Main SCSS Entry Point
 // Uses modern @use syntax for proper concatenation and BEM methodology
 
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 // 1. Abstracts - Variables, mixins, functions (foundation layer)
 @use 'abstracts';
 
@@ -19,6 +15,10 @@
 
 // 5. Pages - Page-specific styles
 @use 'pages';
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 // Design tokens - Available globally in all SCSS files
 @import './tokens/tokens.css';


### PR DESCRIPTION
## Summary
- import the SCSS entry point in the base layout so global styles are bundled
- drop the reference to the missing public stylesheet
- reorder SCSS @use directives ahead of Tailwind directives to satisfy the Sass parser

## Testing
- `npm run build` *(fails: NoAdapterInstalled)*

------
https://chatgpt.com/codex/tasks/task_e_68cedc58cd94832782ed2d67033e80bc